### PR TITLE
composer: allow php ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.2 || ^8.0",
     "contributte/di": "^0.4.2",
     "doctrine/cache": "^1.8.0"
   },


### PR DESCRIPTION
I am going to send migrations to "new README" and GitHub actions in the evening.