### PR TITLE
Documentation fixes

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -32,14 +32,14 @@ extensions:
 
 ```neon
 nettrine.cache:
-  driver: Symfony\Component\Cache\Adapter\FilesystemAdapter(%tempDir%/cache/nettrine-cache)
+  adapter: Symfony\Component\Cache\Adapter\FilesystemAdapter(directory: %tempDir%/cache/nettrine-cache)
 ```
 
 ### Advanced configuration
 
  ```yaml
 nettrine.cache:
-  driver: <class|service>
+  adapter: <class|service>
 ```
 
 > [!WARNING]


### PR DESCRIPTION
- Fix parameter name, it was renamed from `driver` to `adapter`
- Use named parameter for `Symfony\Component\Cache\Adapter\FilesystemAdapter` as cache path is not first parameter (it is 3rd), so this example was not working